### PR TITLE
Better subtitle localization

### DIFF
--- a/Game.bb
+++ b/Game.bb
@@ -35,12 +35,16 @@ End Function
 
 Function SetLanguage%(Language$)
 	lang\CurrentLanguage = Language
-	lang\LanguagePath = "Localization\" + lang\CurrentLanguage + "\"
-	IniWriteBuffer(lang\LanguagePath + LanguageFile)
-	IniWriteBuffer(lang\LanguagePath + SubtitlesFile)
-	IniWriteBuffer(lang\LanguagePath + AchievementsFile)
-	IniWriteBuffer(lang\LanguagePath + LoadingScreensFile)
-	IniWriteBuffer(lang\LanguagePath + SCP294File)
+	If lang\CurrentLanguage = "en-US" Then
+		lang\LanguagePath = ""
+	Else
+		lang\LanguagePath = "Localization\" + lang\CurrentLanguage + "\"
+		IniWriteBuffer(lang\LanguagePath + LanguageFile)
+		IniWriteBuffer(lang\LanguagePath + SubtitlesFile)
+		IniWriteBuffer(lang\LanguagePath + AchievementsFile)
+		IniWriteBuffer(lang\LanguagePath + LoadingScreensFile)
+		IniWriteBuffer(lang\LanguagePath + SCP294File)
+	EndIf
 	opt\Language = Language
 End Function
 

--- a/Source Code/INI_Core.bb
+++ b/Source Code/INI_Core.bb
@@ -49,8 +49,14 @@ Function IniSectionExist%(File$, Section$, AllowBuffer% = True)
 	Return(IniSectionExist_(File, Section, AllowBuffer))
 End Function
 
-Function GetFileLocalString$(File$, Name$, Parameter$, DefaultValue$ = "")
-	Return(IniGetBufferString(lang\LanguagePath + File, Name, Parameter, IniGetBufferString(File, Name, Parameter, DefaultValue)))
+Function GetFileLocalString$(File$, Name$, Parameter$, DefaultValue$ = "", CheckRootFile% = True)
+	Local DefaultValue1$
+	If CheckRootFile Then
+		DefaultValue1 = IniGetBufferString(File, Name, Parameter, DefaultValue)
+	Else 
+		DefaultValue1 = DefaultValue
+	EndIf
+	Return(IniGetBufferString(lang\LanguagePath + File, Name, Parameter, DefaultValue1))
 End Function
 
 Function GetLocalString$(Section$, Parameter$)

--- a/Source Code/Main_Core.bb
+++ b/Source Code/Main_Core.bb
@@ -8361,7 +8361,7 @@ Function Update294%()
 				EndIf
 				
 				If Drink <> "Null" Then
-					StrTemp = GetFileLocalString(SCP294File, Drink, "Dispense Sound")
+					StrTemp = GetFileLocalString(SCP294File, Drink, "Dispense Sound", "", False)
 					If StrTemp = "" Then
 						PlayerRoom\SoundCHN = PlaySound_Strict(LoadTempSound("SFX\SCP\294\Dispense1.ogg"))
 					Else
@@ -8393,12 +8393,12 @@ Function Update294%()
 						EndIf
 					EndIf
 					
-					If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Explosion")) Then 
+					If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Explosion", "", False)) Then 
 						me\ExplosionTimer = 135.0
-						msg\DeathMsg = GetFileLocalString(SCP294File, Drink, "Death Message")
+						msg\DeathMsg = GetFileLocalString(SCP294File, Drink, "Death Message", "", False)
 					EndIf
 					
-					StrTemp = GetFileLocalString(SCP294File, Drink, "Color")
+					StrTemp = GetFileLocalString(SCP294File, Drink, "Color", "", False)
 					
 					Sep1 = Instr(StrTemp, ", ", 1)
 					Sep2 = Instr(StrTemp, ", ", Sep1 + 1)
@@ -8406,8 +8406,8 @@ Function Update294%()
 					G = Trim(Mid(StrTemp, Sep1 + 1, Sep2 - Sep1 - 1))
 					B = Trim(Right(StrTemp, Len(StrTemp) - Sep2))
 					
-					Alpha = Float(GetFileLocalString(SCP294File, Drink, "Alpha", 1.0))
-					Glow = GetFileLocalString(SCP294File, Drink, "Glow")
+					Alpha = Float(GetFileLocalString(SCP294File, Drink, "Alpha", 1.0, False))
+					Glow = GetFileLocalString(SCP294File, Drink, "Glow", "", False)
 					If Glow Then Alpha = -Alpha
 					
 					it.Items = CreateItem("Cup", "cup", EntityX(PlayerRoom\Objects[1], True), EntityY(PlayerRoom\Objects[1], True), EntityZ(PlayerRoom\Objects[1], True), R, G, B, Alpha)

--- a/Source Code/Main_Core.bb
+++ b/Source Code/Main_Core.bb
@@ -4480,46 +4480,46 @@ Function UpdateGUI%()
 							Drink = Right(Drink, Len(Drink) - 9)
 						EndIf
 						
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Message")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Message", "", False)
 						If StrTemp <> "" Then CreateMsg(StrTemp)
 						
-						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Lethal"))
-							msg\DeathMsg = GetFileLocalString(SCP294File, Drink, "Death Message")
+						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Lethal", "", False))
+							msg\DeathMsg = GetFileLocalString(SCP294File, Drink, "Death Message", "", False)
 							Kill()
 						EndIf
-						me\BlurTimer = Max(Int(GetFileLocalString(SCP294File, Drink, "Blur")) * 70.0, 0.0)
+						me\BlurTimer = Max(Int(GetFileLocalString(SCP294File, Drink, "Blur", "", False)) * 70.0, 0.0)
 						If me\VomitTimer = 0.0 Then
-							me\VomitTimer = Int(GetFileLocalString(SCP294File, Drink, "Vomit"))
+							me\VomitTimer = Int(GetFileLocalString(SCP294File, Drink, "Vomit", "", False))
 						Else
-							me\VomitTimer = Min(me\VomitTimer, Int(GetFileLocalString(SCP294File, Drink, "Vomit")))
+							me\VomitTimer = Min(me\VomitTimer, Int(GetFileLocalString(SCP294File, Drink, "Vomit", "", False)))
 						EndIf
-						me\CameraShakeTimer = GetFileLocalString(SCP294File, Drink, "Camera Shake")
-						me\Injuries = Max(me\Injuries + Int(GetFileLocalString(SCP294File, Drink, "Damage")), 0.0)
-						me\Bloodloss = Max(me\Bloodloss + Int(GetFileLocalString(SCP294File, Drink, "Blood Loss")), 0.0)
-						StrTemp =  GetFileLocalString(SCP294File, Drink, "Sound")
+						me\CameraShakeTimer = GetFileLocalString(SCP294File, Drink, "Camera Shake", "", False)
+						me\Injuries = Max(me\Injuries + Int(GetFileLocalString(SCP294File, Drink, "Damage", "", False)), 0.0)
+						me\Bloodloss = Max(me\Bloodloss + Int(GetFileLocalString(SCP294File, Drink, "Blood Loss", "", False)), 0.0)
+						StrTemp =  GetFileLocalString(SCP294File, Drink, "Sound", "", False)
 						If StrTemp <> "" Then PlaySound_Strict(LoadTempSound(StrTemp))
-						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Stomach Ache")) Then I_1025\State[3] = 1.0
+						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Stomach Ache", "", False)) Then I_1025\State[3] = 1.0
 						
-						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Infection")) Then I_008\Timer = I_008\Timer + 1.0
+						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Infection", "", False)) Then I_008\Timer = I_008\Timer + 1.0
 						
-						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Crystallization")) Then I_409\Timer = I_409\Timer + 1.0
+						If StringToBoolean(GetFileLocalString(SCP294File, Drink, "Crystallization", "", False)) Then I_409\Timer = I_409\Timer + 1.0
 						
 						If me\DeathTimer = 0.0 Then
-							me\DeathTimer = Int(GetFileLocalString(SCP294File, Drink, "Death Timer")) * 70.0
+							me\DeathTimer = Int(GetFileLocalString(SCP294File, Drink, "Death Timer", "", False)) * 70.0
 						Else
-							me\DeathTimer = Min(me\DeathTimer, Int(GetFileLocalString(SCP294File, Drink, "Death Timer")) * 70.0)
+							me\DeathTimer = Min(me\DeathTimer, Int(GetFileLocalString(SCP294File, Drink, "Death Timer", "", False)) * 70.0)
 						EndIf
 						
 						; ~ The state of refined items is more than 1.0 (fine setting increases it by 1, very fine doubles it)
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Blink Effect")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Blink Effect", "", False)
 						If StrTemp <> "" Then me\BlinkEffect = Float(StrTemp) ^ SelectedItem\State
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Blink Effect Timer")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Blink Effect Timer", "", False)
 						If StrTemp <> "" Then me\BlinkEffectTimer = Float(StrTemp) * SelectedItem\State
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Stamina Effect")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Stamina Effect", "", False)
 						If StrTemp <> "" Then me\StaminaEffect = Float(StrTemp) ^ SelectedItem\State
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Stamina Effect Timer")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Stamina Effect Timer", "", False)
 						If StrTemp <> "" Then me\StaminaEffectTimer = Float(StrTemp) * SelectedItem\State
-						StrTemp = GetFileLocalString(SCP294File, Drink, "Refuse Message")
+						StrTemp = GetFileLocalString(SCP294File, Drink, "Refuse Message", "", False)
 						If StrTemp <> "" Then
 							CreateMsg(StrTemp)
 						Else

--- a/Source Code/Strict_Functions_Core.bb
+++ b/Source Code/Strict_Functions_Core.bb
@@ -114,7 +114,7 @@ Function LoadSound_Strict%(File$)
 	snd\ReleaseTime = 0
 	If opt\EnableSubtitles Then
 		; ~ Check if the sound has subtitles
-		If (IniSectionExist(lang\LanguagePath + SubtitlesFile, File)) Lor (IniSectionExist(SubtitlesFile, File)) Then snd\HasSubtitles = True
+		If IniBufferSectionExist(lang\LanguagePath + SubtitlesFile, File) Then snd\HasSubtitles = True
 	EndIf
 	If (Not opt\EnableSFXRelease) Then
 		If (Not snd\InternalHandle) Then snd\InternalHandle = LoadSound(snd\Name)

--- a/Source Code/Subtitles_Core.bb
+++ b/Source Code/Subtitles_Core.bb
@@ -53,8 +53,8 @@ Function ShowSubtitles%(Name$)
 	CatchErrors("Uncaught (ShowSubtitles)")
 	
 	Local sub.Subtitles, CurrSub.Subtitles
-	Local Person% = Int(GetFileLocalString(SubtitlesFile, Name, "Person"))
-	Local LinesAmount% = Int(GetFileLocalString(SubtitlesFile, Name, "LinesAmount"))
+	Local Person% = Int(GetFileLocalString(SubtitlesFile, Name, "Person", "", False))
+	Local LinesAmount% = Int(GetFileLocalString(SubtitlesFile, Name, "LinesAmount", "", False))
 	Local SubID%, i%
 	
 	Select Person
@@ -88,8 +88,8 @@ Function ShowSubtitles%(Name$)
 		Else
 			sub.Subtitles = CurrSub.Subtitles
 		EndIf
-		sub\Txt[SubID] = GetFileLocalString(SubtitlesFile, Name, "Txt" + i)
-		sub\Timer[SubID] = 70.0 * Float(GetFileLocalString(SubtitlesFile, Name, "Timer" + i))
+		sub\Txt[SubID] = GetFileLocalString(SubtitlesFile, Name, "Txt" + i, "", False)
+		sub\Timer[SubID] = 70.0 * Float(GetFileLocalString(SubtitlesFile, Name, "Timer" + i, "", False))
 	Next
 	
 	CatchErrors("ShowSubtitles")


### PR DESCRIPTION
Original subtitle localization has a problem, for example:

Chinese subtitles (Localization\zh-CN\Data\subtitles.ini):
```ini
[SFX\SCP\035\Gased1.ogg]
Person = 1
LinesAmount = 9
Txt1 = "- 等等，你在干什么？你他妈——"
Timer1 = 2.91
Timer2 = 2.13
Txt3 = "- 为什么——"
Timer3 = 0.78
Timer4 = 0.39
Txt5 = "- 求你了——"
Timer5 = 0.71
Timer6 = 1.19
Txt7 = "- 我没法呼吸了..."
Timer7 = 0.71
Timer8 = 1.54
Txt9 = "- 不！"
Timer9 = 0.43
```
and English subtitles (Data\subtitles.ini)
```ini
[SFX\SCP\035\Gased1.ogg]
Person=1
LinesAmount=11
Timer1=0.195
Txt2="- Wait, what the hell are you doing?"
Timer2=1.705
Txt3="- What the hell are..."
Timer3=0.8
Txt4="- [COUGHING]"
Timer4=1.55
Txt5="- Will you please why..."
Timer5=1.6
Txt6="- Just please..."
Timer6=1.1
Txt7="- [COUGHING]"
Timer7=1.005
Txt8="- I can't breathe!"
Timer8=0.955
Txt9="- [COUGHING]"
Timer9=1.5
Txt10="- No!"
Timer10=0.4
Txt11="- [COUGHING]"
Timer11=3.81
```

when game reading subtitles, these things will become this:
```ini
[SFX\SCP\035\Gased1.ogg]
Person = 1
LinesAmount = 9
Txt1 = "- 等等，你在干什么？你他妈——"
Timer1 = 2.91
Txt2="- Wait, what the hell are you doing?"
Timer2 = 2.13
Txt3 = "- 为什么——"
Timer3 = 0.78
Txt4="- [COUGHING]"
Timer4 = 0.39
Txt5 = "- 求你了——"
Timer5 = 0.71
Txt6="- Just please..."
Timer6 = 1.19
Txt7 = "- 我没法呼吸了..."
Timer7 = 0.71
Txt8="- I can't breathe!"
Timer8 = 1.54
Txt9 = "- 不！"
Timer9 = 0.43
```

So to fix this bug, the game will only read subtitles from the localized file.