### PR TITLE
Optimize cont1_173 and cont1_173_intro doors

### DIFF
--- a/Source Code/Map_Core.bb
+++ b/Source Code/Map_Core.bb
@@ -5851,18 +5851,20 @@ Function FillRoom%(r.Rooms)
 			d.Doors = CreateDoor(r\x + 1392.0 * RoomScale, r\y + 384.0 * RoomScale, r\z + 64.0 * RoomScale, 90.0, r, True)
 			d\Locked = 1 : d\MTFClose = False
 			
-			d.Doors = CreateDoor(r\x - 640.0 * RoomScale, r\y + 384.0 * RoomScale, r\z + 64.0 * RoomScale, 90.0, r)
+			d.Doors = CreateDoor(r\x - 640.0 * RoomScale, r\y + 384.0 * RoomScale, r\z + 64.0 * RoomScale, -90.0, r)
 			d\Locked = 1 : d\DisableWaypoint = True : d\MTFClose = False
-			FreeEntity(d\Buttons[1]) : d\Buttons[1] = 0
+			FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
+			FreeEntity(d\OBJ2) : d\OBJ2 = 0
 			
 			d.Doors = CreateDoor(r\x + 1264.0 * RoomScale, r\y + 383.9 * RoomScale, r\z + 312.0 * RoomScale, 180.0, r, True, ONE_SIDED_DOOR)
 			d\Locked = 1 : d\MTFClose = False
 			PositionEntity(d\Buttons[0], r\x + 1120.0 * RoomScale, EntityY(d\Buttons[0], True), r\z + 322.0 * RoomScale, True)
 			PositionEntity(d\Buttons[1], r\x + 1120.0 * RoomScale, EntityY(d\Buttons[1], True), r\z + 302.0 * RoomScale, True)
 			
-			d.Doors = CreateDoor(r\x, r\y, r\z + 1184.0 * RoomScale, 0.0, r, False, DEFAULT_DOOR, KEY_CARD_3)
+			d.Doors = CreateDoor(r\x, r\y, r\z + 1184.0 * RoomScale, 180.0, r, False, DEFAULT_DOOR, KEY_CARD_3)
 			d\Locked = 1 : d\DisableWaypoint = True : d\MTFClose = False
-			FreeEntity(d\Buttons[1]) : d\Buttons[1] = 0
+			FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
+			FreeEntity(d\OBJ2) : d\OBJ2 = 0
 			
 			r\Objects[0] = LoadRMesh("GFX\Map\IntroDesk_opt.rmesh", Null)
 			ScaleEntity(r\Objects[0], RoomScale, RoomScale, RoomScale)
@@ -6294,19 +6296,17 @@ Function FillRoom%(r.Rooms)
 			Tex = LoadTexture_Strict("GFX\Map\Textures\Door02.jpg")
 			If opt\Atmosphere Then TextureBlend(Tex, 5)
 			For zTemp = 0 To 1
-				d.Doors = CreateDoor(r\x - 5760.0 * RoomScale, r\y, r\z + ((320.0 + (896.0 * zTemp)) * RoomScale), 0.0, r)
+				d.Doors = CreateDoor(r\x - 5760.0 * RoomScale, r\y, r\z + ((320.0 + (896.0 * zTemp)) * RoomScale), (zTemp * 180.0), r)
 				d\Locked = 1 : d\DisableWaypoint = True : d\MTFClose = False
-				If zTemp = 0 Then
-					FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
-				Else
-					FreeEntity(d\Buttons[1]) : d\Buttons[1] = 0
-				EndIf
+				FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
+				FreeEntity(d\OBJ2) : d\OBJ2 = 0
 				
-				d.Doors = CreateDoor(r\x - 8288.0 * RoomScale, r\y, r\z + ((320.0 + (896.0 * zTemp)) * RoomScale), 0.0, r, zTemp = 0)
-				d\Locked = 1 : d\MTFClose = False : d\MTFClose = False
+				d.Doors = CreateDoor(r\x - 8288.0 * RoomScale, r\y, r\z + ((320.0 + (896.0 * zTemp)) * RoomScale), 180.0, r, zTemp = 0)
+				d\Locked = 1 : d\MTFClose = False
 				If zTemp <> 0 Then 
 					d\DisableWaypoint = True
-					FreeEntity(d\Buttons[1]) : d\Buttons[1] = 0
+					FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
+					FreeEntity(d\OBJ2) : d\OBJ2 = 0
 				EndIf
 				
 				For xTemp = 0 To 2
@@ -6340,6 +6340,7 @@ Function FillRoom%(r.Rooms)
 			d.Doors = CreateDoor(r\x - 3712.0 * RoomScale, r\y - 385.0 * RoomScale, r\z - 2336.0 * RoomScale, 0.0, r)
 			d\AutoClose = False : d\DisableWaypoint = True : d\MTFClose = False
 			FreeEntity(d\Buttons[0]) : d\Buttons[0] = 0
+			FreeEntity(d\OBJ2) : d\OBJ2 = 0
 			
 			; ~ The door from the concrete tunnel to the large hall
 			d.Doors = CreateDoor(r\x - 6864.0 * RoomScale, r\y, r\z - 1248.0 * RoomScale, 90.0, r, True)


### PR DESCRIPTION
Gets rid of the unseeable door objects. Gonna point out that the 173 rooms still have prop collision. Shouldn't these be removed later on or is there a reason they still have prop collision?