### PR TITLE
Tesla Gate won't be activated before Clerk is dead

### DIFF
--- a/Source Code/Events_Core.bb
+++ b/Source Code/Events_Core.bb
@@ -2863,7 +2863,7 @@ Function UpdateEvents%()
 								If EntityDistanceSquared(me\Collider, e\room\Objects[0]) < PowTwo(300.0 * RoomScale) And (Not me\Terminated) And (Not chs\NoTarget) Then
 									StopChannel_Strict(e\SoundCHN)
 									e\SoundCHN = PlaySound2(TeslaActivateSFX, Camera, e\room\Objects[1], 4.0, 0.5)
-									e\EventState = 1.0
+									If (e\room\NPC[0] = Null) Or (e\room\NPC[0]\IsDead) Then e\EventState = 1.0
 								EndIf
 							EndIf
 							For n.NPCs = Each NPCs


### PR DESCRIPTION
I try to fix this: https://discord.com/channels/571954180642701332/571959646185848833/1062928878559043615