### PR TITLE
Change where and when a player can save

### DIFF
--- a/Source Code/Events_Core.bb
+++ b/Source Code/Events_Core.bb
@@ -2332,6 +2332,7 @@ Function UpdateEvents%()
 							PlayerRoom = gateb
 							RemoveEvent(e)
 						EndIf
+						If PlayerInsideElevator Then CanSave = 1
 					EndIf
 				EndIf
 				;[End Block]
@@ -2381,6 +2382,7 @@ Function UpdateEvents%()
 							PlayerRoom = gatea
 							RemoveEvent(e)
 						EndIf
+						If PlayerInsideElevator Then CanSave = 1
 					EndIf
 				EndIf
 				;[End Block]
@@ -6726,7 +6728,7 @@ Function UpdateEvents%()
 					
 					If e\EventState > 0.0 Then
 						e\EventState = e\EventState + fps\Factor[0]
-						
+						CanSave = 0
 						e\room\RoomDoors[1]\Open = False
 						If e\EventState > 70.0 * 2.0 Then
 							If e\room\RoomDoors[0]\Open Then e\room\RoomDoors[0]\SoundCHN = PlaySound2(LoadTempSound("SFX\SCP\914\DoorClose.ogg"), Camera, e\room\RoomDoors[0]\OBJ)
@@ -7987,6 +7989,8 @@ Function UpdateDimension106%()
 					HideRoomsNoColl(r)
 				Next
 				ShowRoomsNoColl(e\room)
+				
+				CanSave = 1
 				
 				PlayerFallingPickDistance = 0.0
 				CurrStepSFX = 1

--- a/Source Code/NPCs_Core.bb
+++ b/Source Code/NPCs_Core.bb
@@ -1058,6 +1058,11 @@ Function UpdateNPCs%()
 								EndIf
 							EndIf
 							
+							If me\FallTimer < -1.0 Then
+								CanSave = False
+								Sprint = 0.0
+							EndIf
+							
 							If me\FallTimer < -250.0 Then
 								MoveToPocketDimension()
 								n\State = 250.0 ; ~ Make SCP-106 idle for a while

--- a/Source Code/NPCs_Core.bb
+++ b/Source Code/NPCs_Core.bb
@@ -1059,7 +1059,7 @@ Function UpdateNPCs%()
 							EndIf
 							
 							If me\FallTimer < -1.0 Then
-								CanSave = False
+								CanSave = 0
 								Sprint = 0.0
 							EndIf
 							


### PR DESCRIPTION
- Cannot save when SCP-914 is refining ~ Could be controversial for speedrunners
- Cannot save at the Pocket Dimension or when being taken by SCP-106 to the Pocket Dimension.
- Cannot save while inside Gate A and B Entrance elevators to prevent players from locking themselves to an ending.