### PR TITLE
Move items within Cont1_895 to better spots

### DIFF
--- a/Source Code/Events_Core.bb
+++ b/Source Code/Events_Core.bb
@@ -2082,7 +2082,10 @@ Function UpdateEvents%()
 									de.Decals = CreateDecal(DECAL_BLOOD_2, EntityX(e\room\OBJ), e\room\y - 1531.0 * RoomScale, EntityZ(e\room\OBJ), 90.0, Rnd(360.0), 0.0, 0.4)
 									EntityParent(de\OBJ, e\room\OBJ)
 									
-									it.Items = CreateItem("Unknown Note", "paper", EntityX(e\room\OBJ), e\room\y - 1526.0 * RoomScale, EntityZ(e\room\OBJ))
+									it.Items = CreateItem("Unknown Note", "paper", EntityX(e\room\OBJ), e\room\y - 1516.0 * RoomScale, EntityZ(e\room\OBJ))
+									EntityType(it\Collider, HIT_ITEM)
+									
+									it.Items = CreateItem("Level 3 Key Card", "key3", EntityX(e\room\OBJ), e\room\y - 1504.0 * RoomScale, EntityZ(e\room\OBJ))
 									EntityType(it\Collider, HIT_ITEM)
 								EndIf
 								If e\room\NPC[0]\Frame = 286.0 Then e\room\NPC[0]\PrevState = 2

--- a/Source Code/Map_Core.bb
+++ b/Source Code/Map_Core.bb
@@ -6135,7 +6135,7 @@ Function FillRoom%(r.Rooms)
 			PositionEntity(r\Objects[0], r\x, - 1320.0 * RoomScale, r\z + 2304.0 * RoomScale)
 			
 			r\Objects[1] = CreatePivot()
-			PositionEntity(r\Objects[1], r\x, r\y - 1532.0 * RoomScale, r\z + 2455.0 * RoomScale)
+			PositionEntity(r\Objects[1], r\x, r\y - 1532.0 * RoomScale, r\z + 2356.0 * RoomScale)
 			
 			For i = 0 To 1
 				EntityParent(r\Objects[i], r\OBJ)
@@ -6164,10 +6164,7 @@ Function FillRoom%(r.Rooms)
 			it.Items = CreateItem("Document SCP-895", "paper", r\x - 688.0 * RoomScale, r\y + 133.0 * RoomScale, r\z - 304.0 * RoomScale)
 			EntityParent(it\Collider, r\OBJ)
 			
-			it.Items = CreateItem("Level 3 Key Card", "key3", r\x + 240.0 * RoomScale, r\y - 1456.0 * RoomScale, r\z + 2064.0 * RoomScale)
-			EntityParent(it\Collider, r\OBJ)
-			
-			it.Items = CreateItem("Night Vision Goggles", "nvg", r\x + 280.0 * RoomScale, r\y - 1456.0 * RoomScale, r\z + 2164.0 * RoomScale)
+			it.Items = CreateItem("Night Vision Goggles", "nvg", r\x + 50.0 * RoomScale, r\y - 1302.0 * RoomScale, r\z + 2415.0 * RoomScale)
 			it\State = Rnd(1000.0)
 			EntityParent(it\Collider, r\OBJ)
 			;[End Block]


### PR DESCRIPTION
Moved SCP-106's spawnpoint pivot to not be inside the coffin's platform. Slightly misplaces where the possesed goggles will point to but should be fine.