### PR TITLE
Fix MTF Spawning

### DIFF
--- a/Source Code/Main_Core.bb
+++ b/Source Code/Main_Core.bb
@@ -8607,25 +8607,27 @@ Function UpdateMTF%()
 				EndIf
 			Next
 			
-			If entrance <> Null Then 
-				If me\Zone = 2 Then
-					If PlayerInReachableRoom() Then PlayAnnouncement("SFX\Character\MTF\Announc.ogg")
-					
-					MTFTimer = fps\Factor[0]
-					
-					Local leader.NPCs
-					
-					For i = 0 To 2
-						n.NPCs = CreateNPC(NPCTypeMTF, EntityX(entrance\OBJ) + 0.3 * (i - 1), 0.6, EntityZ(entrance\OBJ) + 8.0)
+			If entrance <> Null Then
+				If Abs(EntityZ(entrance\OBJ) - EntityZ(me\Collider)) < 36.0 Then
+					If me\Zone = 2 Then
+						If PlayerInReachableRoom() Then PlayAnnouncement("SFX\Character\MTF\Announc.ogg")
 						
-						If i = 0 Then
-							leader = n
-						Else
-							n\MTFLeader = leader
-						EndIf
+						MTFTimer = fps\Factor[0]
 						
-						n\PrevX = i
-					Next
+						Local leader.NPCs
+						
+						For i = 0 To 2
+							n.NPCs = CreateNPC(NPCTypeMTF, EntityX(entrance\OBJ) + 0.3 * (i - 1), 0.6, EntityZ(entrance\OBJ) + 8.0)
+							
+							If i = 0 Then
+								leader = n
+							Else
+								n\MTFLeader = leader
+							EndIf
+							
+							n\PrevX = i
+						Next
+					EndIf
 				EndIf
 			EndIf
 		EndIf


### PR DESCRIPTION
SCP-895(especially this one), SCP-035, and SCP-096 rooms appear to leak into Entrance Zone. In the Original Containment Breach, the MTF wouldn't spawn even if the rooms leaked into Entrance Zone because the trigger for them was pushed back. `If Abs(EntityZ(entrance\obj)-EntityZ(Collider))<30.0 Then` appears to have been used back then to make sure this didn't happen. The player would be required to walk 2/3rds of the way through the first Entrance Zone room before the MTF would spawn. I think a good change would to make it so the moment you actually go beyond the HCZ to EZ checkpoint area the MTF should spawn. This fixes the 3 SCP rooms and makes it so fake checkpoints don't activate MTF either.