### PR TITLE
Incorrect event description

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -117,6 +117,7 @@ Map Creator:
 - Made the Map Creator to be compatible with latest BlitzPlus version.
 
 Bug fixes:
+- Fixed a bug with incorrect description of SCP-005 in MapCreator.
 - Fixed a bug with Ulgrin not triggering on the player when he is reading a document.
 - Fixed a bug with console bind.
 - Fixed SCP-096 triggering while his face is hidden by fog.

--- a/Data/events_MC.ini
+++ b/Data/events_MC.ini
@@ -291,7 +291,7 @@ Descr=Required for SCP-409 to be touchable and updates the elevator.
 Room0=cont2_409
 
 [cont1_005]
-Descr=Event with SCP-106 in the presence of SCP-005.
+Descr=Event with Dr.Maynard has a chance of taking SCP-005.
 Room0=cont1_005
 
 [682_roar]


### PR DESCRIPTION
In version v1.1，UE removed SCP-106 from SCP-005's containment chamber event. But the MapCreator event description still writing "Event with SCP-106 in the presence of SCP-005".
![屏幕截图 2023-04-15 223441](https://user-images.githubusercontent.com/116633144/232232501-9c2bf77b-5ecd-4362-9b02-2b54ab744be5.jpg)
![屏幕截图 2023-04-15 223426](https://user-images.githubusercontent.com/116633144/232232507-13728cb3-a14e-47f3-8238-146add999092.jpg)
