### PR TITLE
Remove translators in Credits.txt

### DIFF
--- a/Credits.txt
+++ b/Credits.txt
@@ -153,32 +153,6 @@
 		XtrithX
 		artoka
 
-*Translators
-
-		Chinese Simplified localization,
-by "ZiYueCommentary"
-
-		Russian localization,
-by "CreatorMasters", "Trill Team" and Nikita Sidorov ("Jabka")
-
-		French localization,
-by "EpicDasherFR"
-
-		Italian localization,
-by Extol ("amogussusimpostor3")
-
-		Germany localization,
-by Tillikum Soyer ("Tillikum")
-
-		Japanese localization,
-by Xing Jie ("XingJieGames")
-
-		Spanish localization,
-by kSuzukuOninuts ("SuzukuKnm")
-
-		Portuguese localization,
-by Ariel ("arielniii")
-
 *Mod Testers
 
 		Alexey Krasnov ("TaskeWSH")


### PR DESCRIPTION
Languages and translators in `Credits.txt` can't be updated in time. 

Instead by [Language List of Ultimate Edition](https://github.com/Jabka666/scpcb-ue-my/wiki/Language-List-of-Ultimate-Edition).