### PR TITLE
Fixed vignette being impersitant

### DIFF
--- a/Source Code/INI_Core.bb
+++ b/Source Code/INI_Core.bb
@@ -416,7 +416,7 @@ Function LoadOptionsINI%()
 	
 	opt\SmoothBars = IniGetInt(OptionFile, "Advanced", "Smooth Bars", True)
 	
-	opt\VignetteEnabled = IniGetInt(OptionFile, "Advanced", "Vignette Ennabled", True)
+	opt\VignetteEnabled = IniGetInt(OptionFile, "Advanced", "Vignette Enabled", True)
 	
 	opt\PlayStartup = IniGetInt(OptionFile, "Advanced", "Play Startup Videos", True)
 	


### PR DESCRIPTION
There's a typo in the code that makes the game read an invalid `Vignette Ennabled` parameter, causing the parameter to be always true on startup.