### PR TITLE
Update loading_screens.jsonc

### DIFF
--- a/Data/loading_screens.jsonc
+++ b/Data/loading_screens.jsonc
@@ -16,7 +16,7 @@
 		"descriptions": [
 			"Yellow Duck: Identical to non-anomalous rubber ducks in design and composition— however, when left unattended in a room, item always appears in a location different from where it was originally placed.",
 			"White Duck: Object has the appearance of a duck wearing a sheet, similar to a simplistic Halloween ghost costume. Duck has been observed to float 5-7cm above solid and liquid surfaces.",
-			"Saxaphone Duck: Object appears to be a duck holding a small saxophone, which it has been observed to \"play\" at random intervals— emitting a single, drawn-out note followed by a series of melodically unrelated notes.",
+			"Saxaphone Duck: Object appears to be a duck with a small saxophone, which it has been observed to \"play\" at random intervals— emitting a single, drawn-out note followed by a series of melodically unrelated notes.",
 			"Orange healing Duck: While duck does not appear to possess any clinically significant healing or painkilling properties, if held by a subject suffering from minor or significant injury, subject will subsequently find injured areas covered with a proportionate number of band-aids, regardless of the nature of the wound."
 		]
 	},
@@ -274,9 +274,9 @@
 		"align_y": "center",
 		"background": false,
 		"descriptions": [
-			"SCP-458 is a large-sized pizza box from the pizza chain  ██████  ██████'s, of their Hot-n-Ready variety. It is made of simple cardboard, measures 25.4cmx25.4cmx2.54cm (10inx10inx1in), and weighs about 20 to 20.49 grams depending on toppings.",
+			"SCP-458 is a large-sized pizza box from the pizza chain [DATA REDACTED], of their Hot-n-Ready variety. It is made of simple cardboard, measures 25.4cmx25.4cmx2.54cm (10inx10inx1in), and weighs about 20 to 20.49 grams depending on toppings.",
 			"What makes SCP-458 an oddity is that, while appearing to be an ordinary pizza box, when it comes into contact with human hands, it instantaneously replicates within it the holder's subconsciously preferred choice of pizza, down to the favorite sauce, cheese, crust, and topping.",
-			"After constant testing showed SCP-458's seemingly infinite power to generate pizza (but with little other use), it has henceforth been placed inside the canteen at Site-██ for free use by personnel. After its open usage has been allowed, personnel morale has shown to have sharply increased."
+			"After constant testing showed SCP-458's seemingly infinite power to generate pizza (but with little other use), it has henceforth been placed inside the canteen at Site-[DATA REDACTED] for free use by personnel. After its open usage has been allowed, personnel morale has shown to have sharply increased."
 		]
 	},
 	{
@@ -286,7 +286,7 @@
 		"align_y": "bottom",
 		"background": true,
 		"descriptions": [
-			"SCP-500 is a small plastic can which at the time of writing contains ██ red pills.",
+			"SCP-500 is a small plastic can which at the time of writing contains [DATA REDACTED] red pills.",
 			"One pill, when taken orally, effectively cures the subject of all diseases within two hours, exact time depending on the severity and amount of the subject's conditions.",
 			"Despite extensive trials, all attempts at synthesizing more of what is thought to be the active ingredient of the pills have been unsuccessful."
 		]


### PR DESCRIPTION
The full block (U+2588) in the SCP description on loading screens looks out of place, as it stands out too much, Imo. I decided to change it to "DATA REDACTED". Also changed "holding" in the description of the duck with the saxophone to "with", as in the game the duck doesn't hold a saxophone.