### PR TITLE
New more logical descriptions of some achievements

### DIFF
--- a/Data/achievements.jsonc
+++ b/Data/achievements.jsonc
@@ -287,7 +287,7 @@
 		},
 		"513": {
 			"name": "If You Ring It, He Will Come",
-			"description": "Ring the Old Bell or its refined variation."
+			"description": "Ring the Old Bell or its variation."
 		},
 		"714": {
 			"name": "Mental Exhaustion",

--- a/Data/achievements.jsonc
+++ b/Data/achievements.jsonc
@@ -287,11 +287,11 @@
 		},
 		"513": {
 			"name": "If You Ring It, He Will Come",
-			"description": "Ring the Old Cowbell."
+			"description": "Ring the Old Bell or its refined variation."
 		},
 		"714": {
 			"name": "Mental Exhaustion",
-			"description": "Found and equipped the Jaded Ring."
+			"description": "Found the Jaded Ring and equipped it or its variation."
 		},
 		"860": {
 			"name": "Two-faced Grove",
@@ -323,11 +323,11 @@
 		},
 		"1025": {
 			"name": "\"Potential Bioweapon\"",
-			"description": "Read the Encyclopedia of Common Diseases."
+			"description": "Read the Encyclopedia of Common (Uncommon) Diseases."
 		},
 		"1048": {
 			"name": "The Architect",
-			"description": "Found the Builder Bear."
+			"description": "Found the Builder Bear or its crude replica."
 		},
 		"1123": {
 			"name": "The Final Solution",


### PR DESCRIPTION
SCP-513: instead of "Ring the Old Bell" - "Ring the Old Bell or its refined variation".

SCP-714: instead of "Found and equipped the Jaded Ring" - "Found the Jaded Ring and equipped it or its variation."

SCP-1025: instead of "Read the Encyclopedia of Common Diseases" - "Read the Encyclopedia of Common (Uncommon) Diseases.

SCP-1048: instead of "Found the Builder Bear" - "Found the Builder Bear or its crude replica."