### PR TITLE
Fix an oversight regarding the Default Font

### DIFF
--- a/Source Code/Graphics_Core.bb
+++ b/Source Code/Graphics_Core.bb
@@ -375,8 +375,6 @@ Function PlayMovie%(MoviePath$)
 	
 	HidePointer()
 	
-	fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
-	
 	Local ScaledGraphicHeight%
 	; ~ The aspect ratio to target
 	Local TargetAspectRatio# = 16.0 / 9.0

--- a/Source Code/Main_Core.bb
+++ b/Source Code/Main_Core.bb
@@ -120,7 +120,7 @@ If opt\DisplayMode = 0 Then CursorIMG = ResizeImageEx(LoadImage_Strict("GFX\Menu
 InitLoadingScreens(LoadingScreensFile)
 
 Function LoadFonts%()
-	If (Not opt\PlayStartup) Then fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
+	fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
 	fo\FontID[Font_Default_Big] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default_Big", "File"), GetFileLocalString(FontsFile, "Default_Big", "Size"))
 	fo\FontID[Font_Digital] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Digital", "File"), GetFileLocalString(FontsFile, "Digital", "Size"))
 	fo\FontID[Font_Digital_Big] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Digital_Big", "File"), GetFileLocalString(FontsFile, "Digital_Big", "Size"))


### PR DESCRIPTION
> remake of #244 

Currently untested, will test in due time

Simply fixes an crash for Linux when running under Wine/Proton when the default font isn't loaded due to an unneeded check

Also makes it so the default font is loaded only once instead of everytime when running the `PlayMovie` function

closes https://github.com/Jabka666/scpcb-ue-my/issues/243