### PR TITLE
Fix Default font loading, again

### DIFF
--- a/Source Code/Graphics_Core.bb
+++ b/Source Code/Graphics_Core.bb
@@ -200,8 +200,6 @@ Function PlayMovie%(MoviePath$)
 	If (Not opt\PlayStartup) Then Return
 	HidePointer()
 	
-	fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
-	
 	Local ScaledGraphicHeight%
 	; ~ The aspect ratio to target
 	Local TargetAspectRatio# = 16.0 / 9.0

--- a/Source Code/Main_Core.bb
+++ b/Source Code/Main_Core.bb
@@ -112,8 +112,6 @@ SetBuffer(BackBuffer())
 
 SeedRnd(MilliSecs())
 
-PlayStartupVideos()
-
 fps\LoopDelay = MilliSecs()
 
 Global CursorIMG%
@@ -122,7 +120,7 @@ If opt\DisplayMode = 0 Then CursorIMG = ResizeImageEx(LoadImage_Strict("GFX\Menu
 InitLoadingScreens(LoadingScreensFile)
 
 Function LoadFonts%()
-	If (Not opt\PlayStartup) Then fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
+	fo\FontID[Font_Default] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default", "File"), GetFileLocalString(FontsFile, "Default", "Size"))
 	fo\FontID[Font_Default_Big] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Default_Big", "File"), GetFileLocalString(FontsFile, "Default_Big", "Size"))
 	fo\FontID[Font_Digital] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Digital", "File"), GetFileLocalString(FontsFile, "Digital", "Size"))
 	fo\FontID[Font_Digital_Big] = LoadFont_Strict(FontsPath + GetFileLocalString(FontsFile, "Digital_Big", "File"), GetFileLocalString(FontsFile, "Digital_Big", "Size"))
@@ -131,6 +129,8 @@ Function LoadFonts%()
 End Function
 
 LoadFonts()
+
+PlayStartupVideos()
 
 SetFontEx(fo\FontID[Font_Default_Big])
 


### PR DESCRIPTION
Based on #245, but for the v2.0 branch. This makes loading the Default font in `PlayMovie` unnecessary by calling `PlayStartupVideos` *after* `LoadFonts`.

Untested because the updated Blitz3D isn't public yet, but confirmed working on `UET_DEV`.