### PR TITLE
Get rid of the specific BX3D version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ http://creativecommons.org/licenses/by-sa/3.0/
 
 Requirements:
 
--	[BlitzX3D (Krimbopple)](https://github.com/krimbopple/BlitzX3D/releases/tag/DX9_V1.2.1_STABLE) v1.2.1 DX9
+-	[BlitzX3D (Krimbopple)](https://github.com/krimbopple/BlitzX3D/releases)
 
 -	[IDEal for Blitz3D](https://web.archive.org/web/20130827150202/http://fungamesfactory.com/download.php?get=IDEalSetup_0.8.94.exe) v0.8.94
 


### PR DESCRIPTION
Since the engine and game are developed concurrently, and the engine is built to be backwards compatible, it shouldn’t be an issue