### PR TITLE
Enable GPU Skinning (included in BX3D 1.2.4)

### DIFF
--- a/Source Code/Graphics_Core.bb
+++ b/Source Code/Graphics_Core.bb
@@ -87,6 +87,7 @@ Function Graphics3DEx%(Width%, Height%, Depth% = 32, Mode% = 2)
 	SetGfxDriver(opt\GFXDriver)
 	Graphics3D(Width, Height, Depth, Mode)
 	TextureFilter("", 8192) ; ~ This turns on Anisotropic filtering for textures
+	GpuSkinning(True)
 	SMALLEST_POWER_TWO = 512.0
 	While SMALLEST_POWER_TWO < Width Lor SMALLEST_POWER_TWO < Height
 		SMALLEST_POWER_TWO = SMALLEST_POWER_TWO * 2.0


### PR DESCRIPTION
Shouldn't be an issue as it will just fallback to CPU if the PC is incapable of handling the shader necessary